### PR TITLE
Changes signature of name() from char const* to char const[]

### DIFF
--- a/include/boost/describe/detail/members.hpp
+++ b/include/boost/describe/detail/members.hpp
@@ -49,7 +49,7 @@ template<class C, class F> constexpr auto mfn( F * p ) { return p; }
 
 #define BOOST_DESCRIBE_MEMBER_IMPL(C, m) , []{ struct _boost_desc { \
     static constexpr auto pointer() noexcept { return BOOST_DESCRIBE_PP_POINTER(C, m); } \
-    static constexpr auto name() noexcept { return BOOST_DESCRIBE_PP_NAME(m); } }; return _boost_desc(); }()
+    static constexpr decltype(BOOST_DESCRIBE_PP_NAME(m)) name() noexcept { return BOOST_DESCRIBE_PP_NAME(m); } }; return _boost_desc(); }()
 
 #if defined(_MSC_VER) && !defined(__clang__)
 

--- a/include/boost/describe/enum.hpp
+++ b/include/boost/describe/enum.hpp
@@ -46,7 +46,7 @@ template<class... T> auto enum_descriptor_fn_impl( int, T... )
 
 #define BOOST_DESCRIBE_ENUM_ENTRY(E, e) , []{ struct _boost_desc { \
     static constexpr auto value() noexcept { return E::e; } \
-    static constexpr auto name() noexcept { return #e; } }; return _boost_desc(); }()
+    static constexpr decltype(#e) name() noexcept { return #e; } }; return _boost_desc(); }()
 
 #define BOOST_DESCRIBE_ENUM_END(E) ); }
 


### PR DESCRIPTION
* This makes it a lot easier to get the size of the string at
compile-time, and in general will improve usage with a compile-time
string library

Signed-off-by: Julien Blanc <julien.blanc@tgcm.eu>